### PR TITLE
Possible typo in the package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "DoNotDisturbPlugin",
+    name: "DoNilDisturbPlugin",
     platforms: [
         .macOS(.v11),
         .iOS(.v13),


### PR DESCRIPTION
You refer to DoNilDisturb (which is a great name) everywhere else except the package name. I thought it might be a typo.